### PR TITLE
Fix conditional changelog generation in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
 
   changelog_gen:
     name: CHANGELOG.MD automatic update
+    if: needs.version_tagging.outputs.newTag!=''
     needs: version_tagging
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The pull request addresses an update to the workflow by adding a condition to run changelog generation only when a new tag is pushed. This change ensures the workflow operates efficiently and as intended in such scenarios.